### PR TITLE
make visually-hidden extend a placeholder

### DIFF
--- a/stylesheets/mixins/_visually_hidden.sass
+++ b/stylesheets/mixins/_visually_hidden.sass
@@ -1,5 +1,8 @@
 // Hide only visually, but have it available for screenreaders: h5bp.com/v
 @mixin visually-hidden
+  @extend %visually-hidden
+
+%visually-hidden
   border: 0
   clip: rect(0 0 0 0)
   height: 1px


### PR DESCRIPTION
- Add a placeholder called "visually-hidden" that contains the styles that were
  previously in the mixin "visually-hidden"
- Modify the "visually-hidden" mixin to merely extend the new "visually-hidden"
  placeholder.

Since visually-hidden is a reusable style that never changes, it should be
harnessed as an extended placeholder to prevent it from being duplicated
unnecessarily.

[This is the way](https://github.com/Snugug/toolkit/blob/master/compass/stylesheets/toolkit/_clearfix.scss) @Snugug often approaches this, and I like it. What do you think?
