### PR TITLE
Added compass-animation gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gem "compass", "~> 0.12.2"
 gem "sass-globbing", "~> 1.0.0"     # Not required for Rails 3.1+
 gem "susy", "~> 1.0.9"
+gem "animation", "~> 0.1.alpha.3"


### PR DESCRIPTION
Added the compass animation gem to the Gemfile so that compass compile
and compass watch wouldn't throw an exception.

Specifying ~>0.1.alpha.3 for compass 0.12 compatibility.
